### PR TITLE
A fix for a couple of menu glitches

### DIFF
--- a/sd_template/SimpleDesk.template.php
+++ b/sd_template/SimpleDesk.template.php
@@ -433,7 +433,7 @@ function template_ticket_block()
 				break;
 			case 'status':
 				echo '
-							<td width="17%" class="shd_nowrap"><img src="', $settings['default_images_url'], '/simpledesk/status.png" class="shd_smallicon" alt="" /> ', template_shd_menu_header('starter', $txt['shd_ticket_status']), '</td>';
+							<td width="17%" class="shd_nowrap"><img src="', $settings['default_images_url'], '/simpledesk/status.png" class="shd_smallicon" alt="" /> ', template_shd_menu_header('status', $txt['shd_ticket_status']), '</td>';
 				break;
 			case 'urgency':
 				echo '
@@ -614,7 +614,7 @@ function template_shd_menu_header($header, $string)
 		$link .= ';so_' . $block_key . '=' . ($block_key != $context['current_block'] ? $block['sort']['item'] : $header) . '_' . $link_direction;
 	}
 
-	$html = '<a href="' . $scripturl . '?action=helpdesk;sa=' . $_REQUEST['sa'] . ($_REQUEST['sa'] == 'viewblock' ? ';block=' . $_REQUEST['block'] : '') . $link . '">' . $string . '</a> ';
+	$html = '<a href="' . $scripturl . '?action=helpdesk;sa=' . $_REQUEST['sa'] . ($_REQUEST['sa'] == 'viewblock' ? ';block=' . $_REQUEST['block'] : '') . $link . $context['shd_dept_link'] . '">' . $string . '</a> ';
 
 	if ($context['ticket_blocks'][$context['current_block']]['sort']['item'] == $header)
 	{


### PR DESCRIPTION
A couple of menu glitches, where selecting the status column would reorder by starter(!) and also that the department link wasn't always included properly in the grid sorting.
