### PR TITLE
Fixes posting with attachments

### DIFF
--- a/sd_source/SimpleDesk-Post.php
+++ b/sd_source/SimpleDesk-Post.php
@@ -2044,6 +2044,8 @@ function shd_handle_attachments()
 				'tmp_name' => $uplfile['tmp_name'],
 				'size' => $uplfile['size'],
 				'id_folder' => $modSettings['currentAttachmentUploadDir'],
+				'mime_type' => !empty($uplfile['type']) ? $uplfile['type'] : get_mime_type($uplfile['tmp_name'], true),
+				'approved' => 1,
 			);
 
 			if (createAttachment($attachmentOptions))


### PR DESCRIPTION
2 Cases:
1. New ticket with attachment and would be valid.
2. New ticket with invalid data (such as missing department), save, get error for missing dept, add dept and save again.

Also add approved = 1 since this makes SMF happy.