### PR TITLE
PHP 8.2

### DIFF
--- a/.github/workflows/Syntax-Check.yml
+++ b/.github/workflows/Syntax-Check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '7.4', '8.0', '8.1' ]
+        php: [ '7.4', '8.0', '8.1', '8.2' ]
     name: PHP ${{ matrix.php }} Syntax Check
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Add PHP 8.2 to syntax checks.  This should be supported as we are not using any deprecated features in 8.2.  However callables have been tested.